### PR TITLE
fix:  apply styles to size & position the bell icon and unread count

### DIFF
--- a/notification-portlet-webcomponents/notification-icon/src/components/NotificationIcon.vue
+++ b/notification-portlet-webcomponents/notification-icon/src/components/NotificationIcon.vue
@@ -3,7 +3,7 @@
     <dropdown id="_uid" no-caret :variant="variant">
       <template slot="button-content">
         <font-awesome-icon icon="bell"/>
-        {{ unreadCount }}
+        <span class="unread-count">{{ unreadCount }}</span>
       </template>
       <dropdown-header>Notifications</dropdown-header>
       <notification-item
@@ -107,5 +107,14 @@ export default {
   @import "../../node_modules/bootstrap/scss/reboot";
   @import "../../node_modules/bootstrap/scss/dropdown";
   @import "../../node_modules/bootstrap/scss/buttons";
+
+  svg.svg-inline--fa {
+    width: 1.25rem;
+  }
+  span.unread-count {
+    position: relative;
+    top: -.25rem;
+    left: .25rem;
+  }
 }
 </style>


### PR DESCRIPTION
@ChristianMurphy -- these styles improved the size & position of the items in the dropdown toggle.  Appearance in consistent in chrome & firefox.

![notification-icon-styles](https://user-images.githubusercontent.com/1127174/49771114-df8a0280-fca4-11e8-962d-093590769f45.png)
