### PR TITLE
fix:  dynamic attribute :class (based on JSON) was not working;  limi…

### DIFF
--- a/notification-portlet-webcomponents/notification-icon/src/components/NotificationIcon.vue
+++ b/notification-portlet-webcomponents/notification-icon/src/components/NotificationIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="notification-icon" :class="{ 'limit-width': limitWidth }">
+  <div class="notification-icon">
     <dropdown id="_uid" no-caret :variant="variant">
       <template slot="button-content">
         <font-awesome-icon icon="bell"/>
@@ -54,10 +54,6 @@ export default {
     debug: {
       type: Boolean,
       default: false
-    },
-    limitWidth: {
-      type: Boolean,
-      default: true
     }
   },
   asyncComputed: {
@@ -123,15 +119,13 @@ export default {
     top: -.25rem;
     left: .25rem;
   }
-}
+  .dropdown-menu {
+    max-width: 30rem;
 
-// for limit-width option
-.notification-icon.limit-width /deep/ .dropdown-menu {
-  max-width: 30rem;
-
-  .dropdown-item {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    .dropdown-item {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 </style>


### PR DESCRIPTION
…tWidth was always false

This setup wasn't working -- in the portal -- in either chrome or firefox.  The `limit-width` class was never applied.

I fought with it for a while, but I think this is a YAGNI situation.